### PR TITLE
test map/set operations when keys/values have meta

### DIFF
--- a/src/collection_check.clj
+++ b/src/collection_check.clj
@@ -14,6 +14,17 @@
 
 ;;;
 
+(defn pr-meta [v]
+  (if-let [m (meta v)]
+    `(with-meta ~v ~m)
+    v))
+
+(def with-meta-gen
+  (gen/fmap
+    (fn [[a b]]
+      (with-meta [a] {:mynum b}))
+    (gen/tuple gen/int gen/int)))
+
 (defn- tuple* [& args]
   (->> args
     (map
@@ -179,6 +190,19 @@
     (assert (= (into (empty b) (take 1 b))
               (reduce #(reduced* (conj %1 %2)) (empty b) b)))))
 
+(defn make-meta-map [s]
+  (into {}
+    (for [v s] [v (meta v)])))
+
+(defn sets-equal-meta [s1 s2]
+  (= (make-meta-map s1) (make-meta-map s2)))
+
+(defn maps-equal-meta [m1 m2]
+  (and (sets-equal-meta (set (keys m1))
+                        (set (keys m2)))
+       (every? #(= (meta (m1 %)) (meta (m2 %)))
+               (keys m1))))
+
 (defn assert-equivalent-vectors [a b]
   (assert-equivalent-collections a b)
   (assert (= (map identity (next a))
@@ -198,6 +222,7 @@
   (assert-equivalent-collections a b)
   (assert (= (set (map #(a %) a))
             (set (map #(b %) b))))
+  (assert (sets-equal-meta a b))
   (assert (and
             (every? #(contains? a %) b)
             (every? #(contains? b %) a))))
@@ -215,6 +240,7 @@
   (assert (and
             (every? #(= (key %) (first %)) a)
             (every? #(= (key %) (first %)) b)))
+  (assert (maps-equal-meta a b))
   (assert (every? #(= (val %) (a (key %)) (b (key %))) a)))
 
 ;;;
@@ -229,7 +255,7 @@
                                     (map (fn [[f & rst]]
                                            (if (empty? rst)
                                              (symbol (name f))
-                                             (list* (symbol (name f)) rst))))
+                                             (list* (symbol (name f)) (map pr-meta rst)))))
                                     (list* '-> 'coll)
                                     pr-str))
                (:result x))))

--- a/test/collection_check_test.clj
+++ b/test/collection_check_test.clj
@@ -6,7 +6,7 @@
 
 (deftest test-identities
   (assert-vector-like 100 [] gen/int)
-  (assert-map-like 100 (sorted-map) gen/int gen/int {:base (sorted-map) :ordered? true})
-  (assert-map-like 100 {} gen/int gen/int)
-  (assert-set-like 100 (sorted-set) gen/int {:base (sorted-set) :ordered? true})
-  (assert-set-like 100 #{} gen/int))
+  (assert-map-like 100 (sorted-map) with-meta-gen with-meta-gen {:base (sorted-map) :ordered? true})
+  (assert-map-like 100 {} with-meta-gen with-meta-gen)
+  (assert-set-like 100 (sorted-set) with-meta-gen {:base (sorted-set) :ordered? true})
+  (assert-set-like 100 #{} with-meta-gen))


### PR DESCRIPTION
kind of a proof-of-concept. The comparison helpers are stolen from the clojure
test suite. They do involve sorting the values, so there should probably be a
switch for this or something.