### PR TITLE
Use `is` instead of `assert`, so the tests run until the end

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,5 +2,6 @@
   :description "fuzz testing for alternate data structures"
   :license {:name "MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/test.check "0.5.9"]]
+  :dependencies [[org.clojure/test.check "0.8.0"]
+                 [com.gfredericks/test.chuck "0.1.21"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]]}})


### PR DESCRIPTION
Uses test.chuck to allow using `is` inside of `for-all`

It also reports each failed assertion

Sample output of a (faked) failure __BEFORE__ this change:

```
› git diff
diff --git src/collection_check.clj src/collection_check.clj
@@ -193,6 +193,7 @@
 (defn assert-equivalent-vectors [a b]
   (assert-equivalent-collections a b)
   (assert (= (first a) (first b)))
+  (assert (= (first a) (last b)))
   (assert (= (map #(nth a %) (range (count a)))
             (map #(nth b %) (range (count b)))))
   
› lein test

lein test collection-check-test

lein test :only collection-check-test/test-identities

ERROR in (test-identities) (collection_check.clj:255)
Uncaught exception, not in assertion.
expected: nil
  actual: java.lang.Exception: Assert failed: (= (first a) (last b))
  actions = (-> coll seq (->> (cons (clojure.core/with-meta [0] {:foo 0}))) (->> (cons (clojure.core/with-meta [-1] {:foo 0}))) (into (empty coll)))
 at collection_check$assert_not_failed.invoke (collection_check.clj:255)
    collection_check$assert_vector_like.invoke (collection_check.clj:270)
    collection_check$assert_vector_like.invoke (collection_check.clj:263)
    collection_check_test/fn (collection_check_test.clj:11)
    ...
    ... --> many many lines...
    clojure.lang.Cons.next (Cons.java:39)
    clojure.lang.RT.boundedLength (RT.java:1654)
    .... --> many many more lines...
    clojure.lang.Var.invoke (Var.java:383)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.main.main (main.java:37)

Ran 1 tests containing 1 assertions.
0 failures, 1 errors.
Tests failed.
```

Sample output __AFTER__ this change:

```
› git diff
diff --git src/collection_check.clj src/collection_check.clj
   (is (= (first a) (first b)))
+  (is (= (first a) (last b)))
   (is (= (map #(nth a %) (range (count a)))
             (map #(nth b %) (range (count b)))))

› lein test

lein test collection-check-test

lein test :only collection-check-test/test-identities

FAIL in (test-identities) (clojure_test.clj:17)
vector-like
{:result false, :seed 1439941633124, :failing-size 4, :num-tests 5, :fail [(([:transient] [:assoc! 942 [4]] [:assoc! 919 [1]] [:persistent!]) ([:transient] [:assoc! 787 [1]] [:pop!] [:assoc! 854
 [-4]] [:persistent!]) ([:seq] [:cons [-1]] [:map-id] [:into]))], :shrunk {:total-nodes-visited 48, :depth 9, :result false, :smallest [(([:transient] [:conj! [0]] [:persistent!]) ([:seq] [:cons
 [-1]] [:into]))]}}
expected: (not-falsey-or-exception? (:result result))
  actual: (not (not-falsey-or-exception? false))

  actions =  (-> coll transient (conj! (clojure.core/with-meta [0] {:foo 0})) persistent! seq (->> (cons (clojure.core/with-meta [-1] {:foo 0}))) (into (empty coll))) 


lein test :only collection-check-test/test-identities

FAIL in (test-identities) (collection_check.clj:198)
vector-like
expected: (= (first a) (last b))
  actual: (not (= [-1] [0]))

Ran 1 tests containing 84 assertions.
2 failures, 0 errors.
Tests failed. 
```